### PR TITLE
Add Docker support for Azure Container Apps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+ENV PORT=3000
+EXPOSE 3000
+
+CMD ["npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -187,6 +187,23 @@ npm run build
 npm run deploy
 ```
 
+### Azure Container Apps でのデプロイ
+
+1. Docker イメージのビルド
+```bash
+docker build -t <registry>/summer-horror-novel:latest .
+```
+
+2. Azure Container Registry へプッシュ
+```bash
+docker push <registry>/summer-horror-novel:latest
+```
+
+3. コンテナアプリの作成
+```bash
+az containerapp up --name summer-horror-novel --resource-group <リソースグループ> --environment <環境名> --image <registry>/summer-horror-novel:latest --target-port 3000 --ingress external
+```
+
 ## デバッグ情報
 
 ### 解決済みの問題

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "wrangler pages dev dist",
-    "deploy": "wrangler pages deploy dist"
+    "deploy": "wrangler pages deploy dist",
+    "start": "wrangler pages dev dist --ip 0.0.0.0 --port $PORT"
   },
   "dependencies": {
     "hono": "^4.6.14"


### PR DESCRIPTION
## Summary
- add Dockerfile to build and run project for Azure Container Apps
- expose start script in package.json
- document how to build and deploy the container to Azure

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b5710450688327bd7b5fc9764b69f1